### PR TITLE
Avoid initializing martor on Django formset templates

### DIFF
--- a/martor/static/martor/js/martor.js
+++ b/martor/static/martor/js/martor.js
@@ -920,7 +920,7 @@
     };
 
     $(function() {
-        $('.main-martor').martor();
+        $('.main-martor').not('[data-field-name*=-__prefix__-]').martor();
     });
 
     if ('django' in window && 'jQuery' in window.django)


### PR DESCRIPTION
This fixes the ace editor initialization filling the editor with a bunch
of Xs. This fixes DMOJ/online-judge#1394.