### PR TITLE
Add option to disable the upload button in the widget UI

### DIFF
--- a/martor/templates/martor/toolbar.html
+++ b/martor/templates/martor/toolbar.html
@@ -52,10 +52,12 @@
     <div class="ui icon button no-border markdown-selector markdown-image-link" title="{% trans 'Insert Image Link' %} (Ctrl+Shift+I)">
       <i class="image icon"></i>
     </div>
-    <div class="ui icon button no-border markdown-selector markdown-image-upload" title="{% trans 'Upload an Image' %}">
-      <i class="upload icon"></i>
-      <input name="markdown-image-upload" class="button" type="file" accept="image/*" title="{% trans 'Upload an Image' %}">
-    </div>
+    {% if uploads_enabled %}
+      <div class="ui icon button no-border markdown-selector markdown-image-upload" title="{% trans 'Upload an Image' %}">
+        <i class="upload icon"></i>
+        <input name="markdown-image-upload" class="button" type="file" accept="image/*" title="{% trans 'Upload an Image' %}">
+      </div>
+    {% endif %}
     <div class="ui icon button no-border markdown-selector markdown-emoji" title="{% trans 'Insert Emoji' %}">
       <i class="heart icon"></i>
     </div>

--- a/martor/widgets.py
+++ b/martor/widgets.py
@@ -12,6 +12,7 @@ from .settings import (
 
 
 class MartorWidget(forms.Textarea):
+    UPLOADS_ENABLED = False
 
     def render(self, name, value, attrs=None, renderer=None, **kwargs):
         # Make the settings the default attributes to pass
@@ -47,7 +48,8 @@ class MartorWidget(forms.Textarea):
             'martor': widget,
             'field_name': name,
             'emoji_enabled': emoji_enabled,
-            'mentions_enabled': mentions_enabled
+            'mentions_enabled': mentions_enabled,
+            'uploads_enabled': self.UPLOADS_ENABLED,
         })
 
     class Media:


### PR DESCRIPTION
This only disables it in the UI. Backend checks will be done in the custom image uploader. Part of DMOJ/online-judge#2293.